### PR TITLE
Fix rubocop lint warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"
 
-gem "nokogiri", "~> 1.11"
+gem 'nokogiri', '~> 1.11'
 
-gem "docopt", "~> 0.6.1"
+gem 'docopt', '~> 0.6.1'

--- a/css-gather
+++ b/css-gather
@@ -13,7 +13,7 @@ docs = <<~DOC
     #{__FILE__} <url>
 DOC
 
-def main url
+def main(url)
   doc = Nokogiri.HTML(URI.open(url))
   stylesheets = doc.css('link[rel="stylesheet"]')
   stylesheets.each do |link|

--- a/css-gather
+++ b/css-gather
@@ -2,7 +2,7 @@
 
 # frozen_string_literal: true
 
-require "docopt"
+require 'docopt'
 require 'nokogiri'
 require 'open-uri'
 

--- a/css-gather
+++ b/css-gather
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# frozen_string_literal: true
+
 require "docopt"
 require 'nokogiri'
 require 'open-uri'

--- a/css-gather
+++ b/css-gather
@@ -14,10 +14,10 @@ docs = <<~DOC
 DOC
 
 def main(url)
-  doc = Nokogiri.HTML(URI.open(url))
+  doc = Nokogiri.HTML(URI.parse(url).open)
   stylesheets = doc.css('link[rel="stylesheet"]')
   stylesheets.each do |link|
-    puts URI.open(link['href']).read
+    puts URI.parse(link['href']).open.read
   end
 end
 

--- a/css-gather
+++ b/css-gather
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+
 require "docopt"
 require 'nokogiri'
 require 'open-uri'

--- a/css-gather
+++ b/css-gather
@@ -6,11 +6,11 @@ require 'docopt'
 require 'nokogiri'
 require 'open-uri'
 
-docs = <<DOC
-Fetch CSS
+docs = <<~DOC
+  Fetch CSS
 
-Usage:
-  #{__FILE__} <url>
+  Usage:
+    #{__FILE__} <url>
 DOC
 
 def main url


### PR DESCRIPTION
Patch up several lint warning Rubocop pointed out.

Most of these are simple style fixes, but the [Security/Open](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/Open) warning seems like a legit security improvement.

CC @andyg0808 