### PR TITLE
Reject print stylesheets

### DIFF
--- a/css-gather
+++ b/css-gather
@@ -17,6 +17,7 @@ def main(url)
   doc = Nokogiri.HTML(URI.parse(url).open)
   stylesheets = doc.css('link[rel="stylesheet"],style')
   stylesheets.each do |stylesheet|
+    next if stylesheet['media'] == 'print'
     case stylesheet.name
     when 'link'
       puts URI.parse(stylesheet['href']).open.read


### PR DESCRIPTION
We don't want to include print sytlesheets as a part of our critical CSS calculation. Reject those out.

CC @andyg0808 