### PR TITLE
CSS Gather: Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.7.3
+
+RUN apt-get update
+RUN apt-get install -y \
+  nodejs \
+  npm \
+  chromium \
+  libxss1
+
+WORKDIR /app
+COPY . ./
+
+COPY Gemfile Gemfile.lock ./
+
+RUN gem install bundler -v 2.4.6
+RUN bundle check || bundle install
+
+COPY package.json package-lock.json ./
+
+RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get install -y \
   libxss1
 
 WORKDIR /app
-COPY . ./
 
 COPY Gemfile Gemfile.lock ./
 
@@ -18,3 +17,5 @@ RUN bundle check || bundle install
 COPY package.json package-lock.json ./
 
 RUN npm install
+
+COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.3
+FROM ruby:latest
 
 RUN apt-get update
 RUN apt-get install -y \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,4 +14,4 @@ DEPENDENCIES
   nokogiri (~> 1.11)
 
 BUNDLED WITH
-   2.2.3
+   2.4.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.4'
+
+services:
+  app:
+    image: css-gather
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+      - gem_cache:/usr/local/bundle/gems
+      - node_modules:/app/node_modules
+
+volumes:
+  gem_cache:
+  node_modules:


### PR DESCRIPTION
This adds a Dockerfile and docker-compose with the instructions on how to spin up this
app in a docker container. In the past, getting all of the different versions to work with 
each other has been a pain. This should help with that.

QA:
--
- Locally clone the repo.
- Run `docker-compose build`
- Run `docker run css-gather ./run.rb https://www.ifixit.com`
- The output should be written to stdout.

cc @sctice-ifixit @djmetzle @batbattur @ardelato 

Closes: https://github.com/ifixit/ifixit/issues/46405