### PR TITLE
Save screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+critical-css-screenshots

--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ Generate critical css by running the `run.sh` command in a css-gather container 
 ```sh
 docker run css-gather ./run.rb https://www.ifixit.com
 ```
+
+Generate critical css and save [screenshots](https://github.com/pocketjoso/penthouse/blob/master/examples/screenshots.js#L1-L4) in critical-css-screenshots folder:
+
+```sh
+mkdir critical-css-screenshots
+docker run --mount type=bind,source="$(pwd)/critical-css-screenshots",target=/app/critical-css-screenshots css-gather ./run.rb https://www.ifixit.com
+```

--- a/critical-css.js
+++ b/critical-css.js
@@ -2,6 +2,8 @@
 
 const yargs = require('yargs')
 const penthouse = require('penthouse')
+const fs = require("fs");
+const path = require("path");
 
 const args = yargs(process.argv.slice(2))
   .usage('$0 [url..]', 'Extract the critical CSS from the passed blob of CSS', (yargs) => {
@@ -35,5 +37,21 @@ function findCriticalCss(cssString, url) {
     timeout: 120000,
     width: 4096,
     height: 2160,
-    blockJSRequests: false
+    blockJSRequests: false,
+    screenshots: {
+      basePath: getScreenshotPath(url),
+      type: 'jpeg',
+      quality: 100
+    }
   })}
+
+// Returns a relative path for the screenshot using the url
+function getScreenshotPath(url) {
+  const screenshotsDir = "critical-css-screenshots";
+  // sanitize the url to use it as a filename
+  const filename = url.replace(/[:/]/g, '-');
+  if (!fs.existsSync(screenshotsDir)) {
+    fs.mkdirSync(screenshotsDir);
+  }
+  return path.join(screenshotsDir, filename)
+}

--- a/critical-css.js
+++ b/critical-css.js
@@ -49,7 +49,7 @@ function findCriticalCss(cssString, url) {
 function getScreenshotPath(url) {
   const screenshotsDir = "critical-css-screenshots";
   // sanitize the url to use it as a filename
-  const filename = url.replace(/[:/]/g, '-');
+  const filename = url.replace(/[?/:<>"|*]/g, "-");
   if (!fs.existsSync(screenshotsDir)) {
     fs.mkdirSync(screenshotsDir);
   }


### PR DESCRIPTION
## Summary
Now we can save the screenshots when generating the critical-css, [ref](https://github.com/pocketjoso/penthouse/blob/master/examples/screenshots.js#L1-L4).
This will be helpful in debugging the weekly update pr changes and when QAing.

## QA Notes
I will be QAing it in a separate pull on `iFixit/ifixit` side when updating the `critical-css` workflow.

qa_req 0

connects https://github.com/iFixit/ifixit/issues/46792