### PR TITLE
Add exclude option for penthouse `forceExclude` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ Generate critical css and save [screenshots](https://github.com/pocketjoso/penth
 mkdir critical-css-screenshots
 docker run --mount type=bind,source="$(pwd)/critical-css-screenshots",target=/app/critical-css-screenshots css-gather ./run.rb https://www.ifixit.com
 ```
+
+Generate critical css and exclude certain css selectors from the critical css:
+
+```sh
+docker run css-gather./run.rb https://www.ifixit.com/ --exclude=.skip-to-content --exclude=/#contentFloat/
+```
+This will remove `.skip-to-content` and any css selector that matches the `/#contentFloat/` regex.

--- a/critical-css.js
+++ b/critical-css.js
@@ -34,13 +34,8 @@ function main(urls) {
 }
 
 function findCriticalCss(cssString, url) {
-  // When a regex is passed from a command line it converts to a string,
-  // so we need to convert it back to a regex
-  const excludeArr = args['exclude'].map((arg) =>
-    arg.startsWith("/") && arg.endsWith("/")
-      ? new RegExp(arg.slice(1, -1))
-      : arg
-  );
+  const excludeArr = validateArrayRegexes(args['exclude']);
+
   return penthouse({
     url,
     cssString,
@@ -67,4 +62,25 @@ function getScreenshotPath(url) {
     fs.mkdirSync(screenshotsDir);
   }
   return path.join(screenshotsDir, filename)
+}
+
+// When a regex is passed from a command line it converts to a string,
+// so we need to convert it back to a regex
+function validateArrayRegexes(arr) {
+  return arr.map((str) => {
+    if (str.startsWith("/") && str.lastIndexOf("/") > 0) {
+      // Extract the regular expression pattern and flags from the string
+      const lastSlashIndex = str.lastIndexOf("/");
+      const pattern = str.substring(1, lastSlashIndex);
+      const flags = str.substring(lastSlashIndex + 1);
+      // Create a new RegExp object with the pattern and flags
+      try {
+        return new RegExp(pattern, flags);
+      } catch (error) {
+        return str;
+      }
+    } else {
+      return str;
+    }
+  });
 }

--- a/critical-css.js
+++ b/critical-css.js
@@ -34,6 +34,13 @@ function main(urls) {
 }
 
 function findCriticalCss(cssString, url) {
+  // When a regex is passed from a command line it converts to a string,
+  // so we need to convert it back to a regex
+  const excludeArr = args['exclude'].map((arg) =>
+    arg.startsWith("/") && arg.endsWith("/")
+      ? new RegExp(arg.slice(1, -1))
+      : arg
+  );
   return penthouse({
     url,
     cssString,
@@ -43,7 +50,7 @@ function findCriticalCss(cssString, url) {
     width: 4096,
     height: 2160,
     blockJSRequests: false,
-    forceExclude: args['exclude'],
+    forceExclude: excludeArr,
     screenshots: {
       basePath: getScreenshotPath(url),
       type: 'jpeg',

--- a/critical-css.js
+++ b/critical-css.js
@@ -11,6 +11,11 @@ const args = yargs(process.argv.slice(2))
       describe: 'The URL to compare to',
       type: 'string',
     })
+    yargs.option('exclude', {
+      describe: 'Exclude css selectors to remove in critical css (the `forceExclude` option in penthouse)',
+      type: 'array',
+      default: [],
+    })
   }).argv
 
 main(args['url'])
@@ -38,6 +43,7 @@ function findCriticalCss(cssString, url) {
     width: 4096,
     height: 2160,
     blockJSRequests: false,
+    forceExclude: args['exclude'],
     screenshots: {
       basePath: getScreenshotPath(url),
       type: 'jpeg',


### PR DESCRIPTION
## Summary
Added option to exclude certain css selectors from the critical css using the `forceExclude` option in penthouse.

## QA notes
We can run the `critical-css.yml` workflow from the `iFixit/ifixit` side (with this branch specified) to verify it still works. 
qa_req 0

connects [#47316](https://github.com/ifixit/ifixit/issues/47316)