### PR TITLE
Add forceInclude option for `:where` selectors

### DIFF
--- a/critical-css.js
+++ b/critical-css.js
@@ -46,7 +46,7 @@ function findCriticalCss(cssString, url) {
     height: 2160,
     blockJSRequests: false,
     forceExclude: excludeArr,
-    forceInclude: [/where/i],
+    forceInclude: [/^:(\w+)\(/i],
     screenshots: {
       basePath: getScreenshotPath(url),
       type: 'jpeg',

--- a/critical-css.js
+++ b/critical-css.js
@@ -46,6 +46,7 @@ function findCriticalCss(cssString, url) {
     height: 2160,
     blockJSRequests: false,
     forceExclude: excludeArr,
+    forceInclude: [/where/i],
     screenshots: {
       basePath: getScreenshotPath(url),
       type: 'jpeg',


### PR DESCRIPTION
## Summary
For some reason, penthouse doesn't think that `:where` selectors are not part of the critical css. 
Let's add it to the config so that it includes the `:where` selectors in the generated critical css.

Edit: The new regex will match selectors like the following: `:where()`, `:has()`, `:not()`, `:host()`, `:root()`.

See https://github.com/iFixit/ifixit/pull/47766#issuecomment-1544460438 for more info.

## QA notes
We can qa this on `iFixit/ifixit` side by running the `critical.css` workflow (with this branch checked out). 

cc: @ianrohde @mlahargou 