### PR TITLE
Penthouse: Update penthouse fork commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,7 +1569,7 @@
     },
     "node_modules/penthouse": {
       "version": "2.3.3",
-      "resolved": "git+ssh://git@github.com/iFixit/penthouse.git#c4d8533cc07072f9b8ff869b10aa465701585f8a",
+      "resolved": "git+ssh://git@github.com/iFixit/penthouse.git#8a497c2829a5d2e4b8e35744b1b885baefb135a9",
       "license": "MIT",
       "dependencies": {
         "css-mediaquery": "^0.1.2",
@@ -3863,7 +3863,7 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "penthouse": {
-      "version": "git+ssh://git@github.com/iFixit/penthouse.git#c4d8533cc07072f9b8ff869b10aa465701585f8a",
+      "version": "git+ssh://git@github.com/iFixit/penthouse.git#8a497c2829a5d2e4b8e35744b1b885baefb135a9",
       "from": "penthouse@iFixit/penthouse#master",
       "requires": {
         "css-mediaquery": "^0.1.2",


### PR DESCRIPTION
## Summary
Updates our penthouse fork to include the changes from https://github.com/iFixit/penthouse/pull/2.

Now, the preferred store will be always set to `US` when generating the critical css.

## QA notes
1. Make sure the CI check passes.
2. Download the artifact from the CI run and verify that the preferred store is set to `US` from the `before` screenshot. 

closes https://github.com/iFixit/css-gather/issues/13