### PR TITLE
CSS Gather: Fix flakiness

### DIFF
--- a/critical-css.js
+++ b/critical-css.js
@@ -20,16 +20,20 @@ const args = yargs(process.argv.slice(2))
 
 main(args['url'])
 
-function main(urls) {
+async function main(urls) {
   let cssString = ""
   process.stdin.on('data', str => cssString += str)
-  process.stdin.on('end', () => {
-    urls.map(url => {
+  process.stdin.on('end', async () => {
+    const cssPromises = urls.map(url => {
       process.stderr.write(`Gathering critical CSS for ${url}\n`);
-      findCriticalCss(cssString, url).then(criticalCss => {
-        process.stdout.write(criticalCss)
-      })
-    })
+      return findCriticalCss(cssString, url);
+    });
+
+    const cssArray = await Promise.all(cssPromises);
+
+    for (const css of cssArray) {
+       process.stdout.write(css);
+    }
   })
 }
 


### PR DESCRIPTION
This took quite some time to track down. We were fetching the 
critical css for all pages in the url list asynchronously. This was 
fine, but we were also outputting to stdout asynchronously. This
 meant that the css that we ran through our postprocessing scripts 
later would always receive the css in a different order.

Now, we still fetch the css asynchronously so it's quick, but we 
always output to stdout in the same order as the input urls array.

QA:
--
This is a bit hard to test so I made a script for myself. This script
commonly fails on master, but on this branch there never seem to
be differences in the output css.

```bash
#!/bin/bash

# The base name for output files
base_name="out"

# Run the docker command 10 times and output to different files
for i in {1..3}; do
    docker run css-gather ./run.rb --include prosemirror-all https://en.ifixit.com/Wiki/Ring_Video_Doorbell_Troubleshooting https://en.ifixit.com/Wiki/Xbox_One_Wireless_Controller_Troubleshooting https://en.ifixit.com/Wiki/MacBook_water_damage_-_The_definitive_guide > "${base_name}${i}.css"
done

# Compare the files to each other
for i in {1..2}; do
    for j in $(seq $((i+1)) 3); do
        if ! diff -q "${base_name}${i}.css" "${base_name}${j}.css" > /dev/null; then
            echo "Difference found between files ${base_name}${i}.css and ${base_name}${j}.css"
        else
            echo "No differences between files ${base_name}${i}.css and ${base_name}${j}.css"
        fi
    done
done

# Optional: Remove the output files after diffing
# Uncomment the line below to enable file removal
# rm ${base_name}*.css

echo "Finished comparing files."
```

The real test will be to see if the flakiness that we commonly see is fixed.

Closes: https://github.com/iFixit/ifixit/issues/50016

cc @iFixit/qae @ianrohde 